### PR TITLE
Fix empty batch

### DIFF
--- a/src/main/clojure/clojure/more/async.clj
+++ b/src/main/clojure/clojure/more/async.clj
@@ -403,19 +403,18 @@
        (if (identical? ch in)
          (if (nil? v)
            (when close? (a/close! out))
-           (let [xs (rf xs v)]
-             (when
-                 (loop [n n
-                        xs xs]
-                   (if (== n size)
-                     (a/>!! out xs)
-                     (let [[v ch] (a/alts!! [in t])]
-                       (if (identical? ch in)
-                         (if (nil? v)
-                           (and (a/>!! out xs) close? (a/close! out))
-                           (recur (unchecked-inc n) (rf xs v)))
-                         (a/>!! out xs)))))
-               (recur 1 init))))
+           (when
+               (loop [n n
+                      xs (rf xs v)]
+                 (if (== n size)
+                   (a/>!! out xs)
+                   (let [[v ch] (a/alts!! [in t])]
+                     (if (identical? ch in)
+                       (if (nil? v)
+                         (and (a/>!! out xs) close? (a/close! out))
+                         (recur (unchecked-inc n) (rf xs v)))
+                       (a/>!! out xs)))))
+             (recur 1 init)))
          (recur 1 init))))))
 
 (comment
@@ -449,19 +448,18 @@
          (if (identical? ch in)
            (if (nil? v)
              (when close? (a/close! out))
-             (let [xs (rf xs v)]
-               (when
-                   (loop [n n
-                          xs xs]
-                     (if (== n size)
-                       (a/>! out xs)
-                       (let [[v ch] (a/alts! [in t])]
-                         (if (identical? ch in)
-                           (if (nil? v)
-                             (and (a/>! out xs) close? (a/close! out))
-                             (recur (unchecked-inc n) (rf xs v)))
-                           (a/>! out xs)))))
-                 (recur 1 init))))
+             (when
+                 (loop [n n
+                        xs (rf xs v)]
+                   (if (== n size)
+                     (a/>! out xs)
+                     (let [[v ch] (a/alts! [in t])]
+                       (if (identical? ch in)
+                         (if (nil? v)
+                           (and (a/>! out xs) close? (a/close! out))
+                           (recur (unchecked-inc n) (rf xs v)))
+                         (a/>! out xs)))))
+               (recur 1 init)))
            (recur 1 init)))))))
 
 (defn batch

--- a/src/main/clojure/clojure/more/async.clj
+++ b/src/main/clojure/clojure/more/async.clj
@@ -397,16 +397,15 @@
   ([in out size timeout rf init close?]
    (assert (pos? size))
    (loop [n 1
-          t (a/timeout timeout)
           xs init]
-     (let [[v ch] (a/alts!! [in t])]
+     (let [t (a/timeout timeout)
+           [v ch] (a/alts!! [in t])]
        (if (identical? ch in)
          (if (nil? v)
            (when close? (a/close! out))
            (let [xs (rf xs v)]
              (when
                  (loop [n n
-                        t t
                         xs xs]
                    (if (== n size)
                      (a/>!! out xs)
@@ -414,10 +413,10 @@
                        (if (identical? ch in)
                          (if (nil? v)
                            (and (a/>!! out xs) close? (a/close! out))
-                           (recur (unchecked-inc n) t (rf xs v)))
+                           (recur (unchecked-inc n) (rf xs v)))
                          (a/>!! out xs)))))
-               (recur 1 (a/timeout timeout) init))))
-         (recur 1 (a/timeout timeout) init))))))
+               (recur 1 init))))
+         (recur 1 init))))))
 
 (comment
   (def out (a/chan))
@@ -444,16 +443,15 @@
    (assert (pos? size))
    (a/go
      (loop [n 1
-            t (a/timeout timeout)
             xs init]
-       (let [[v ch] (a/alts! [in t])]
+       (let [t (a/timeout timeout)
+             [v ch] (a/alts! [in t])]
          (if (identical? ch in)
            (if (nil? v)
              (when close? (a/close! out))
              (let [xs (rf xs v)]
                (when
                    (loop [n n
-                          t t
                           xs xs]
                      (if (== n size)
                        (a/>! out xs)
@@ -461,10 +459,10 @@
                          (if (identical? ch in)
                            (if (nil? v)
                              (and (a/>! out xs) close? (a/close! out))
-                             (recur (unchecked-inc n) t (rf xs v)))
+                             (recur (unchecked-inc n) (rf xs v)))
                            (a/>! out xs)))))
-                 (recur 1 (a/timeout timeout) init))))
-           (recur 1 (a/timeout timeout) init)))))))
+                 (recur 1 init))))
+           (recur 1 init)))))))
 
 (defn batch
   "Takes messages from in and batch them until reaching size or

--- a/src/test/clojure/clojure/more/async_test.clj
+++ b/src/test/clojure/clojure/more/async_test.clj
@@ -104,6 +104,17 @@
       (t/is (= #{5 6} (a/<!! out)))
       (a/close! in)
       (t/is (nil? (a/<!! out)))))
+  (t/testing "empty batch"
+    (let [out (a/chan)
+          in (a/chan)]
+      (a/thread
+        (sut/batch!! in out 3 220 conj #{} true))
+      (t/is (= :timeout
+               (a/alt!!
+                out :batch
+                (a/timeout 400) :timeout)))
+      (a/close! in)
+      (t/is (nil? (a/<!! out)))))
   (t/testing "batch async timeout"
     (let [out (a/chan)
           f (ticker)
@@ -112,6 +123,17 @@
       (t/is (= #{1 2} (a/<!! out)))
       (t/is (= #{3 4} (a/<!! out)))
       (t/is (= #{5 6} (a/<!! out)))
+      (a/close! in)
+      (t/is (nil? (a/<!! out)))))
+  (t/testing "empty async batch"
+    (let [out (a/chan)
+          in (a/chan)]
+      (a/thread
+        (sut/batch!! in out 3 220 conj #{} true))
+      (t/is (= :timeout
+               (a/alt!!
+                 out :batch
+                 (a/timeout 400) :timeout)))
       (a/close! in)
       (t/is (nil? (a/<!! out))))))
 


### PR DESCRIPTION
`batch` would produce an empty batch every timeout to `out` channel.

Fix implementation adapted from @jjttjj's (Justin Tirrell).

Closes #1 